### PR TITLE
Adding photos to account screen and suitemates list

### DIFF
--- a/suite-life/app/components/Suitemate.js
+++ b/suite-life/app/components/Suitemate.js
@@ -1,22 +1,35 @@
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View, Image } from "react-native";
 import colors from "../config/colors";
 import AppText from "./AppText";
 
 export default function Suitemate({
   name,
+  photoURL = null,
   pronouns,
   style = null,
   textStyle = null,
 }) {
   return (
     <View style={[styles.container, style]}>
-      <AppText style={styles.title} numberOfLines={1}>
-        {name}
-      </AppText>
-      <AppText style={styles.text} numberOfLines={1}>
-        {pronouns}
-      </AppText>
+      <Image
+        source={{
+          uri: photoURL,
+        }}
+        style={styles.image}
+        resizeMode={"contain"}
+      />
+      <View style={[styles.nameContainer, style]}>
+        <AppText style={styles.title} numberOfLines={1}>
+          {name}
+        </AppText>
+
+        {pronouns.length > 0 && (
+          <AppText style={styles.text} numberOfLines={1}>
+            {pronouns}
+          </AppText>
+        )}
+      </View>
     </View>
   );
 }
@@ -26,8 +39,17 @@ const styles = StyleSheet.create({
     backgroundColor: colors.tertiary,
     borderRadius: 10,
     flex: 1,
-    justifyContent: "space-evenly",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    alignItems: "center",
     padding: 15,
+  },
+  image: { borderRadius: 30, height: 60, width: 60, marginRight: 15 },
+  nameContainer: {
+    backgroundColor: colors.tertiary,
+    borderRadius: 10,
+    flex: 1,
+    justifyContent: "space-evenly",
   },
   title: {
     color: colors.black,

--- a/suite-life/app/screens/SuiteAccountScreen.js
+++ b/suite-life/app/screens/SuiteAccountScreen.js
@@ -58,7 +58,11 @@ export default function AccountScreen({ navigation }) {
           data={suitemates}
           keyExtractor={(suitemate) => suitemate.id.toString()}
           renderItem={({ item }) => (
-            <Suitemate name={item.name} pronouns={item.pronouns} />
+            <Suitemate
+              name={item.name}
+              photoURL={item.photoURL}
+              pronouns={item.pronouns}
+            />
           )}
           ItemSeparatorComponent={HorizontalSpaceSeparator}
         />

--- a/suite-life/app/screens/account/AccountScreen.js
+++ b/suite-life/app/screens/account/AccountScreen.js
@@ -28,15 +28,13 @@ import {
 } from "../../testing/unitTests";
 
 export default function AccountScreen({ navigation }) {
-  const [name, setName] = useState("");
-  const [pronouns, setPronouns] = useState("");
+  const [user, setUser] = useState(null);
 
   useEffect(() => {
-    getUserData(auth.currentUser.uid).then((userData) => {
-      setName(userData.name);
-      setPronouns(userData.pronouns);
+    getUserData().then((val) => {
+      setUser(val);
     });
-  });
+  }, [auth]);
 
   async function runTests() {
     let chores_res = await TestChores();
@@ -55,23 +53,32 @@ export default function AccountScreen({ navigation }) {
     <RegistrationContext.Consumer>
       {(setRegistered) => (
         <Screen style={styles.screen}>
+          {user && (
+            <Image
+              source={{
+                uri: user.photoURL,
+              }}
+              style={styles.image}
+              resizeMode={"contain"}
+            />
+          )}
+          <View style={styles.editContainer}>
+            <TouchableWithoutFeedback
+              onPress={() => {
+                navigation.navigate(routes.ACCOUNT_EDIT, {
+                  name: user.name,
+                  pronouns: user.pronouns,
+                });
+              }}
+            >
+              <AppText style={styles.edit}>Edit</AppText>
+            </TouchableWithoutFeedback>
+          </View>
           <View style={styles.headerContainer}>
-            <AppTitle style={styles.title}>{name}</AppTitle>
-            <View style={styles.loginContainer}>
-              <TouchableWithoutFeedback
-                onPress={() => {
-                  navigation.navigate(routes.ACCOUNT_EDIT, {
-                    name: name,
-                    pronouns: pronouns,
-                  });
-                }}
-              >
-                <AppText style={styles.edit}>Edit</AppText>
-              </TouchableWithoutFeedback>
-            </View>
+            <AppTitle style={styles.title}>{user ? user.name : ""}</AppTitle>
           </View>
 
-          <AppText style={styles.pronouns}>{pronouns}</AppText>
+          <AppText style={styles.pronouns}>{user ? user.pronouns : ""}</AppText>
           <View style={styles.spacer} />
           <View style={styles.logoutContainer}>
             <AppButton
@@ -117,8 +124,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   edit: {
+    position: "absolute",
+    right: 20,
+    top: 20,
     color: colors.primary,
-    justifyContent: "flex-end",
+    // justifyContent: "flex-end",
   },
   headerContainer: {
     flexDirection: "row",
@@ -131,6 +141,8 @@ const styles = StyleSheet.create({
     height: 200,
     borderRadius: 100,
     resizeMode: "cover",
+    marginTop: 10,
+    marginBottom: 10,
   },
   logout: {
     alignSelf: "flex-end",
@@ -144,7 +156,7 @@ const styles = StyleSheet.create({
   logoutContainer: {
     width: "95%",
   },
-  loginContainer: {
+  editContainer: {
     position: "absolute",
     right: 20,
   },


### PR DESCRIPTION
Adding photos in other places where people might expect to see. In the future, the Google account photo will be used for the profile picture, set as the user registers. For backwards compatibility, random 200x200 photos were chosen for our accounts.